### PR TITLE
Add wraps decorator to keep dataclasse's init signature invariant

### DIFF
--- a/src/ethereum_types/frozen.py
+++ b/src/ethereum_types/frozen.py
@@ -3,6 +3,7 @@ Dataclass extension that supports immutability.
 """
 
 from dataclasses import is_dataclass, replace
+from functools import wraps
 from typing import (
     Any,
     Callable,
@@ -48,6 +49,7 @@ _P = ParamSpec("_P")
 def _make_init_function(
     f: Callable[Concatenate[_S, _P], None]
 ) -> Callable[Concatenate[_S, _P], None]:
+    @wraps(f)
     def init_function(self: _S, *args: _P.args, **kwargs: _P.kwargs) -> None:
         will_be_frozen = kwargs.pop("_frozen", True)
         assert isinstance(will_be_frozen, bool)

--- a/tests/test_frozen.py
+++ b/tests/test_frozen.py
@@ -1,4 +1,6 @@
+import inspect
 from dataclasses import dataclass
+from types import MappingProxyType
 
 import pytest
 
@@ -10,6 +12,22 @@ from ethereum_types.frozen import modify, slotted_freezable
 class Mock:
     a: int
     b: str
+
+
+def test_slotted_freezable_init_signature() -> None:
+    assert inspect.signature(Mock.__init__).parameters == MappingProxyType(
+        {
+            "self": inspect.Parameter(
+                "self", inspect.Parameter.POSITIONAL_OR_KEYWORD
+            ),
+            "a": inspect.Parameter(
+                "a", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=int
+            ),
+            "b": inspect.Parameter(
+                "b", inspect.Parameter.POSITIONAL_OR_KEYWORD, annotation=str
+            ),
+        }
+    )
 
 
 def test_slotted_freezable_init() -> None:


### PR DESCRIPTION
## Summary

This PR adds a `@wraps` decorator to the `_make_init_function` decorator so that the
decorated `__init__` method retains its docstring and parameter names.

This is especially useful for other packages using inspection on dataclasses (like [hypothesis](https://hypothesis.readthedocs.io/en/latest/data.html#hypothesis.strategies.builds)).

Solves #4
